### PR TITLE
Fix the date format issue for the API calls

### DIFF
--- a/events_frontend/src/data/api.ts
+++ b/events_frontend/src/data/api.ts
@@ -38,8 +38,8 @@ export interface EventTime {
 
 // Fetch events and add some fields for easy display
 export const fetchEvents = async () => {
-  const startDate = DateTime.now().minus({ days: 1 }).toISO(); //yesterday
-  const endDate = DateTime.now().minus({ months: 3 }).toISO();
+  const startDate = DateTime.now().toISODate();
+  const endDate = DateTime.now().minus({ months: 3 }).toISODate();
   const prodUrl = `/v1/events?start_date=${startDate}&end_date=${endDate}`;
   const localUrl = "/example.json";
   const url = process.env.NODE_ENV === "development" ? localUrl : prodUrl;


### PR DESCRIPTION
This PR
* Fixes an issues where dates were formatted incorrectly. They incorrectly included a timestamp which the API does not need. 
* Sets the startDate to today instead of yesterday. Setting it to yesterday was an incomplete attempt at fixing the overnight-event problem. I think we can better solve that issue another way (let's chat about it)
