### PR TITLE
Fix the text color in the SelectSomething dropdown

### DIFF
--- a/events_frontend/src/components/EventListPage.tsx
+++ b/events_frontend/src/components/EventListPage.tsx
@@ -13,7 +13,7 @@ export const EventListPage = () => (
         alignItems="top"
         maxWidth={{ base: "100%", lg: "1000px" }}
         marginX="auto"
-        paddingTop={8}
+        paddingTop={{ base: 0, md: 8 }}
         minHeight="80vh"
       >
         <Box display={{ base: "none", sm: "none", md: "block" }}>

--- a/events_frontend/src/components/SelectSomething.tsx
+++ b/events_frontend/src/components/SelectSomething.tsx
@@ -74,6 +74,7 @@ export const SelectSomething: FC<SelectSomethingProps> = ({
               value={option.value}
               fontSize="xl"
               fontWeight="semibold"
+              color="black"
               isDisabled={option.count === 0}
             >
               <HStack>


### PR DESCRIPTION
This PR:
* Sets the color on the dropdown to be readable
* Removes some unneeded space around the filters on mobile
