### PR TITLE
Link urls in descriptions and keep them from breaking the layout

### DIFF
--- a/events_frontend/package-lock.json
+++ b/events_frontend/package-lock.json
@@ -30,6 +30,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.2.1",
+        "react-linkify-it": "^1.0.8",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -16538,6 +16539,24 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-linkify-it": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/react-linkify-it/-/react-linkify-it-1.0.8.tgz",
+      "integrity": "sha512-QjwhIaCXmJ2CiFIl4mIOYN+Z+OhwRLHNMKmWG9SSAzKgpltOnOQjzvj8ruhnvOhgKRc6yqjW0vH0J6LEbTm50Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/anantoghosh"
+        },
+        {
+          "type": "individual",
+          "url": "https://ko-fi.com/anantoghosh"
+        }
+      ],
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",

--- a/events_frontend/package.json
+++ b/events_frontend/package.json
@@ -25,6 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",
+    "react-linkify-it": "^1.0.8",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/events_frontend/src/components/EventCard.tsx
+++ b/events_frontend/src/components/EventCard.tsx
@@ -26,6 +26,7 @@ import {
 import { EVENT_TYPE_COLORS } from "../data/constants";
 import { Event } from "../data/api";
 import { IconWithText } from "./IconWithText";
+import { LinkItUrl } from "react-linkify-it";
 
 export interface EventCardProps {
   event: Event;
@@ -57,7 +58,9 @@ export const EventCard: FC<EventCardProps> = ({ event }) => {
         {event.name}
       </Heading>
 
-      <Text mb={3}>{event.description}</Text>
+      <Text mb={3}>
+        <LinkItUrl className="inline-link">{event.description}</LinkItUrl>
+      </Text>
 
       <Stack direction="row" alignItems="center" spacing={4}>
         <IconWithText icon={BiCalendar}>{event.dateFormatted}</IconWithText>

--- a/events_frontend/src/index.css
+++ b/events_frontend/src/index.css
@@ -11,3 +11,8 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.inline-link {
+    word-break: break-word;
+    color: var(--chakra-colors-red-400);
+}


### PR DESCRIPTION
I noticed that long links were breaking the layout in the event tracker. This is because sometimes descriptions have long urls which don't wrap properly, causing the div they're rendered within to widen too much. This fixes that by:
- using [react-linkify-it](https://www.npmjs.com/package/react-linkify-it) to wrap urls as links.
- Applying a style to those wrapped links which adds `word-break: break-word` so that the url text wraps properly.